### PR TITLE
Use text/template as configs shouldn't need escapeing

### DIFF
--- a/template.go
+++ b/template.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	"text/template"
 	"log"
 	"os"
 )


### PR DESCRIPTION
text/template provides a similar interface as html/template without
special considerations for HTML safety, as it copies the values in verbatim
without worrying about escaping.  As a config template likely do not
need escaping, it seems like a good fit in solving issue #1.

Closes #1 