### PR TITLE
Use a loop to populate cms

### DIFF
--- a/template.go
+++ b/template.go
@@ -117,8 +117,8 @@ func (tp *TemplateProcessor) sync(configmaps []string) {
 			log.Println(err)
 			return
 		}
-		for _, c := range cmList.Items {
-			cms = append(cms, &c)
+		for i := range cmList.Items {
+			cms = append(cms, &cmList.Items[i])
 		}
 	}
 


### PR DESCRIPTION
As we loop on the size of the configmap template search we populate the
cms slice with pointers to the different configmap structs.  With the
interator we point to the same part of the iterator multiple times,
effectivly pointing to the last item to be iterated on multiple times.

I doubt this is the best way to solve this, but this should
effectivly illistrate a possible solution to the issue.

Issue #3