### PR TITLE
Process all templates in a namespace

### DIFF
--- a/template.go
+++ b/template.go
@@ -109,7 +109,7 @@ func process(namespaces, configmaps []string, noop bool) {
 }
 
 func (tp *TemplateProcessor) sync(configmaps []string) {
-	var cms []*ConfigMap
+	var cms []ConfigMap
 
 	if len(configmaps) == 0 {
 		cmList, err := getConfigMaps(tp.namespace)
@@ -118,7 +118,7 @@ func (tp *TemplateProcessor) sync(configmaps []string) {
 			return
 		}
 		for _, c := range cmList.Items {
-			cms = append(cms, &c)
+			cms = append(cms, c)
 		}
 	}
 
@@ -128,11 +128,12 @@ func (tp *TemplateProcessor) sync(configmaps []string) {
 			log.Println(err)
 			continue
 		}
-		cms = append(cms, cm)
+		cms = append(cms, *cm)
 	}
 
 	for _, c := range cms {
-		if err := tp.processConfigMapTemplate(c); err != nil {
+		err := tp.processConfigMapTemplate(&c)
+		if err != nil {
 			log.Println(err)
 			continue
 		}


### PR DESCRIPTION
I noticed it was only processing the first template it found for $count of all templates it found in a namespace (by adding some debugging), with this patch it will walk through all templates it finds in each namespace.