### PR TITLE
Add detailed error log when konfd got a non-20x responses from hyperkube

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -77,7 +77,11 @@ func getConfigMap(namespace, name string) (*ConfigMap, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, errors.New("non 200 response code")
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting config map; got HTTP %v status code and body (%s)", resp.StatusCode, data)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -106,7 +110,11 @@ func getSecret(namespace, name string) (*Secret, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, errors.New("non 200 response code")
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting secret; got HTTP %v status code and body (%s)", resp.StatusCode, data)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -132,7 +140,11 @@ func getConfigMaps(namespace string) (*ConfigMapList, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New("non 200 response code")
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error updating config maps; got HTTP %v status code and body (%s)", resp.StatusCode, data)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -192,7 +204,11 @@ func createConfigMap(c *ConfigMap) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 201 {
-		return fmt.Errorf("error creating configmap %s; got HTTP %v status code", c.Metadata.Name, resp.StatusCode)
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error creating configmap %s; got HTTP %v status code and body (%s)", c.Metadata.Name, resp.StatusCode, data)
 	}
 
 	return nil
@@ -212,7 +228,11 @@ func createSecret(s *Secret) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 201 {
-		return fmt.Errorf("error creating secrets %s; got HTTP %v status code", s.Metadata.Name, resp.StatusCode)
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error creating secrets %s; got HTTP %v status code and body (%s)", s.Metadata.Name, resp.StatusCode, data)
 	}
 
 	return nil
@@ -237,7 +257,11 @@ func updateConfigMap(c *ConfigMap) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("error updating configmap %s; got HTTP %v status code", c.Metadata.Name, resp.StatusCode)
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error updating configmap %s; got HTTP %v status code and body (%s)", c.Metadata.Name, resp.StatusCode, data)
 	}
 
 	return nil
@@ -262,7 +286,11 @@ func updateSecret(s *Secret) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("error updating secret %s; got HTTP %v status code", s.Metadata.Name, resp.StatusCode)
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error updating secret %s; got HTTP %v status code and body (%s)", s.Metadata.Name, resp.StatusCode, data)
 	}
 
 	return nil
@@ -274,7 +302,11 @@ func getNamespaces() (*NamespaceList, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New("non 200 response code")
+		data, err := readHTTPResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting namespaces; got HTTP (%v) status code and body (%s)", resp.StatusCode, data)
 	}
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -301,4 +333,13 @@ func waitForKubernetesProxy() {
 		resp.Body.Close()
 		return
 	}
+}
+
+func readHTTPResponse(resp *http.Response) (string, error) {
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bodyBytes), nil
 }


### PR DESCRIPTION
Debugging #8 was difficult due to lack of detail error logging. This PR aims to add http response code and error detail in the http request's body to the logs to ease troubleshooting.

`konfd`'s log before:

```
2018/02/27 07:52:18 Starting konfd...
2018/02/27 07:52:18 Get http://127.0.0.1:8001/api: dial tcp 127.0.0.1:8001: getsockopt: connection refused
2018/02/27 07:53:19 non 200 response code
2018/02/27 07:53:19 Syncing templates complete. Next sync in 60 seconds.
```

After:

```
2018/02/27 08:25:53 Starting konfd...
2018/02/27 08:25:54 Get http://127.0.0.1:8001/api: dial tcp 127.0.0.1:8001: getsockopt: connection refused
2018/02/27 08:25:55 error getting namespaces; got HTTP (403) status code ({"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces is forbidden: User \"system:serviceaccount:default:default\" cannot list namespaces at the cluster scope","reason":"Forbidden","details":{"kind":"namespaces"},"code":403}
2018/02/27 08:25:55 Syncing templates complete. Next sync in 60 seconds.
```